### PR TITLE
fix: deposit/withdraw form doesn't reset once tx is sent

### DIFF
--- a/src/app/slinks/page.tsx
+++ b/src/app/slinks/page.tsx
@@ -52,6 +52,11 @@ function GetCardSimple(strat: StrategyInfo) {
     return balance;
   }, [balance]);
 
+   // Function to reset the input fields to their initial state
+   const resetDepositForm = () => {
+    setAmount(MyNumber.fromZero());
+  };
+
   return (
     <Card
       key={strat.id}
@@ -111,6 +116,7 @@ function GetCardSimple(strat: StrategyInfo) {
               isDisabled:
                 amount.isZero() || amount.compare(maxAmount.toEtherStr(), 'gt'),
             }}
+            resetDepositForm={resetDepositForm}
           />
         </Box>
       </Flex>

--- a/src/app/slinks/page.tsx
+++ b/src/app/slinks/page.tsx
@@ -52,8 +52,8 @@ function GetCardSimple(strat: StrategyInfo) {
     return balance;
   }, [balance]);
 
-   // Function to reset the input fields to their initial state
-   const resetDepositForm = () => {
+  // Function to reset the input fields to their initial state
+  const resetDepositForm = () => {
     setAmount(MyNumber.fromZero());
   };
 

--- a/src/components/Deposit.tsx
+++ b/src/components/Deposit.tsx
@@ -78,6 +78,14 @@ export default function Deposit(props: DepositProps) {
     };
   }, [amount, props]);
 
+    // Function to reset the input fields to their initial state
+    const resetDepositForm = () => {
+      setAmount(MyNumber.fromEther('0', selectedMarket.decimals));
+      setRawAmount('');
+      setDirty(false);
+    };
+  
+
   // constructs tx calls
   const { calls, actions } = useMemo(() => {
     const actions = props.callsInfo(amount, address || '0x0', provider);
@@ -310,6 +318,7 @@ export default function Deposit(props: DepositProps) {
           }}
           selectedMarket={selectedMarket}
           strategy={props.strategy}
+          resetDepositForm={resetDepositForm}
         />
       </Center>
 

--- a/src/components/Deposit.tsx
+++ b/src/components/Deposit.tsx
@@ -78,13 +78,12 @@ export default function Deposit(props: DepositProps) {
     };
   }, [amount, props]);
 
-    // Function to reset the input fields to their initial state
-    const resetDepositForm = () => {
-      setAmount(MyNumber.fromEther('0', selectedMarket.decimals));
-      setRawAmount('');
-      setDirty(false);
-    };
-  
+  // Function to reset the input fields to their initial state
+  const resetDepositForm = () => {
+    setAmount(MyNumber.fromEther('0', selectedMarket.decimals));
+    setRawAmount('');
+    setDirty(false);
+  };
 
   // constructs tx calls
   const { calls, actions } = useMemo(() => {

--- a/src/components/TxButton.tsx
+++ b/src/components/TxButton.tsx
@@ -71,7 +71,7 @@ export default function TxButton(props: TxButtonProps) {
     }
 
     if (isSuccess && data && data.transaction_hash) {
-      props.resetDepositForm()
+      props.resetDepositForm();
       mixpanel.track('Transaction success', {
         strategyId: props.txInfo.strategyId,
         actionType: props.txInfo.actionType,

--- a/src/components/TxButton.tsx
+++ b/src/components/TxButton.tsx
@@ -61,6 +61,7 @@ export default function TxButton(props: TxButtonProps) {
 
   useEffect(() => {
     if (data && data.transaction_hash) {
+      props.resetDepositForm();
       // initiates a toast and adds the tx to tx history if successful
       monitorNewTx({
         txHash: data.transaction_hash,
@@ -71,7 +72,6 @@ export default function TxButton(props: TxButtonProps) {
     }
 
     if (isSuccess && data && data.transaction_hash) {
-      props.resetDepositForm();
       mixpanel.track('Transaction success', {
         strategyId: props.txInfo.strategyId,
         actionType: props.txInfo.actionType,

--- a/src/components/TxButton.tsx
+++ b/src/components/TxButton.tsx
@@ -35,6 +35,7 @@ interface TxButtonProps {
   justDisableIfNoWalletConnect?: boolean;
   selectedMarket?: TokenInfo;
   strategy?: IStrategyProps;
+  resetDepositForm: () => void;
 }
 
 export default function TxButton(props: TxButtonProps) {
@@ -70,6 +71,7 @@ export default function TxButton(props: TxButtonProps) {
     }
 
     if (isSuccess && data && data.transaction_hash) {
+      props.resetDepositForm()
       mixpanel.track('Transaction success', {
         strategyId: props.txInfo.strategyId,
         actionType: props.txInfo.actionType,


### PR DESCRIPTION
### PR Fixes:
- Reset deposit/withdraw state after transaction

Resolves #110  

### Vercel website link
[deployed link](https://starkfarm-client-git-reset-katezeroandonecs-projects.vercel.app/?_vercel_share=iNeijI80oDIhm2xAUsatF8dTBkhtgv51)

### Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
- [x] My PR passes all checks (build, lint, formatting, etc)
